### PR TITLE
Use notifyUrl not returnUrl for callback

### DIFF
--- a/src/Message/DirectPostAuthorizeRequest.php
+++ b/src/Message/DirectPostAuthorizeRequest.php
@@ -22,7 +22,7 @@ class DirectPostAuthorizeRequest extends DirectPostAbstractRequest
         $data['EPS_TIMESTAMP'] = gmdate('YmdHis');
         $data['EPS_FINGERPRINT'] = $this->generateFingerprint($data);
         $data['EPS_RESULTURL'] = $this->getReturnUrl();
-        $data['EPS_CALLBACKURL'] = $this->getReturnUrl();
+        $data['EPS_CALLBACKURL'] = $this->getNotifyUrl();
         $data['EPS_REDIRECT'] = 'TRUE';
         $data['EPS_CURRENCY'] = $this->getCurrency();
 

--- a/src/Message/DirectPostAuthorizeRequest.php
+++ b/src/Message/DirectPostAuthorizeRequest.php
@@ -22,7 +22,7 @@ class DirectPostAuthorizeRequest extends DirectPostAbstractRequest
         $data['EPS_TIMESTAMP'] = gmdate('YmdHis');
         $data['EPS_FINGERPRINT'] = $this->generateFingerprint($data);
         $data['EPS_RESULTURL'] = $this->getReturnUrl();
-        $data['EPS_CALLBACKURL'] = $this->getNotifyUrl();
+        $data['EPS_CALLBACKURL'] = $this->getNotifyUrl() ?: $this->getReturnUrl();
         $data['EPS_REDIRECT'] = 'TRUE';
         $data['EPS_CURRENCY'] = $this->getCurrency();
 


### PR DESCRIPTION
Omnipay supports a notifyUrl for callbacks and a returnUrl for the browser. This patch causes the notifyUrl to be used for callbacks by securePay
