### PR TITLE
Updated the real gateway name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require league/omnipay omnipay/securepay
 
 The following gateways are provided by this package:
 
-* SecurePay
+* SecurePay_DirectPost
 
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay)
 repository.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ composer require league/omnipay omnipay/securepay
 The following gateways are provided by this package:
 
 * SecurePay_DirectPost
+* SecurePay_SecureXML
 
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay)
 repository.


### PR DESCRIPTION
I spent a lot of time finding the gateway name because using simply 'SecurePay' didn't work.
It returns 'Omnipay\SecurePay\Gateway' not found.

After spent hours of research the real gateway name is 'SecurePay_DirectPost'