### PR TITLE
Fix phpunit complaining about extra HTTP headers

### DIFF
--- a/tests/Mock/SecureXMLAuthorizeRequestSuccess.txt
+++ b/tests/Mock/SecureXMLAuthorizeRequestSuccess.txt
@@ -1,6 +1,3 @@
-HTTP/1.1 100 Continue
-Server: Microsoft-IIS/5.0
-Date: Mon, 19 Apr 2004 06:19:48 GMT
 HTTP/1.1 200 OK
 Server: Microsoft-IIS/5.0
 Date: Mon, 19 Apr 2004 06:20:01 GMT

--- a/tests/Mock/SecureXMLEchoTestRequestSuccess.txt
+++ b/tests/Mock/SecureXMLEchoTestRequestSuccess.txt
@@ -1,6 +1,3 @@
-HTTP/1.1 100 Continue
-Server: Microsoft-IIS/5.0
-Date: Mon, 19 Apr 2004 06:19:48 GMT
 HTTP/1.1 200 OK
 Server: Microsoft-IIS/5.0
 Date: Mon, 19 Apr 2004 06:20:01 GMT

--- a/tests/Mock/SecureXMLPurchaseRequestInsufficientFundsFailure.txt
+++ b/tests/Mock/SecureXMLPurchaseRequestInsufficientFundsFailure.txt
@@ -1,6 +1,3 @@
-HTTP/1.1 100 Continue
-Server: Microsoft-IIS/5.0
-Date: Mon, 19 Apr 2004 06:19:48 GMT
 HTTP/1.1 200 OK
 Server: Microsoft-IIS/5.0
 Date: Mon, 19 Apr 2004 06:20:01 GMT

--- a/tests/Mock/SecureXMLPurchaseRequestSendFailure.txt
+++ b/tests/Mock/SecureXMLPurchaseRequestSendFailure.txt
@@ -1,6 +1,3 @@
-HTTP/1.1 100 Continue
-Server: Microsoft-IIS/5.0
-Date: Mon, 19 Apr 2004 06:19:48 GMT
 HTTP/1.1 200 OK
 Server: Microsoft-IIS/5.0
 Date: Mon, 19 Apr 2004 06:20:01 GMT

--- a/tests/Mock/SecureXMLPurchaseRequestSendSuccess.txt
+++ b/tests/Mock/SecureXMLPurchaseRequestSendSuccess.txt
@@ -1,6 +1,3 @@
-HTTP/1.1 100 Continue
-Server: Microsoft-IIS/5.0
-Date: Mon, 19 Apr 2004 06:19:48 GMT
 HTTP/1.1 200 OK
 Server: Microsoft-IIS/5.0
 Date: Mon, 19 Apr 2004 06:20:01 GMT


### PR DESCRIPTION
The SecureXML mocks have been broken in recent phpunit versions, this
works (tested with phpunit 6.5.13)